### PR TITLE
A21N Fix bug in PW variant where the ILS (rad nav) is not auto-tuned

### DIFF
--- a/hsim-a321neo/src/systems/fmgcPW/src/index.ts
+++ b/hsim-a321neo/src/systems/fmgcPW/src/index.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2021-2023 FlyByWire Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { ApproachUtils } from '@flybywiresim/fbw-sdk';
+import { FlightPlanManager } from './flightplanning/FlightPlanManager';
+import { getFlightPhaseManager } from '@fmgc/flightphase';
+import { FlightPlanAsoboSync } from './flightplanning/FlightPlanAsoboSync';
+import { GuidanceManager } from './guidance/GuidanceManager';
+import { ManagedFlightPlan } from './flightplanning/ManagedFlightPlan';
+import { GuidanceController } from './guidance/GuidanceController';
+import { EfisSymbols } from './efis/EfisSymbols';
+import { DescentPathBuilder } from './guidance/vnav/descent/DescentPathBuilder';
+import { initComponents, updateComponents, recallMessageById } from './components';
+import { WaypointBuilder } from './flightplanning/WaypointBuilder';
+import { RawDataMapper } from './flightplanning/RawDataMapper';
+import { Navigation, SelectedNavaidMode, SelectedNavaidType } from './navigation/Navigation';
+
+function initFmgcLoop(baseInstrument: BaseInstrument, flightPlanManager: FlightPlanManager): void {
+    initComponents(baseInstrument, flightPlanManager);
+}
+
+function updateFmgcLoop(deltaTime: number): void {
+    updateComponents(deltaTime);
+}
+
+export {
+    getFlightPhaseManager,
+    FlightPlanManager,
+    ManagedFlightPlan,
+    FlightPlanAsoboSync,
+    GuidanceManager,
+    GuidanceController,
+    initFmgcLoop,
+    updateFmgcLoop,
+    recallMessageById,
+    EfisSymbols,
+    DescentPathBuilder,
+    WaypointBuilder,
+    RawDataMapper,
+    ApproachUtils,
+    Navigation,
+    SelectedNavaidMode,
+    SelectedNavaidType,
+};


### PR DESCRIPTION
The ILS should have been auto-tuned when ILS approach procedure is selected in FMGC and the airplane is at least 300nm from destination or in approach phase.