### PR TITLE
fix(mcdu): Sync CDU Wind Pages for all types

### DIFF
--- a/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a318-ceo/CDU/A320_Neo_CDU_WindPage.js
+++ b/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a318-ceo/CDU/A320_Neo_CDU_WindPage.js
@@ -112,17 +112,23 @@ class CDUWindPage {
             requestButton = "REQUEST [color]amber";
         }
 
-        let alternateCell = "[ ]°/[ ][color]cyan";
+        let alternateHeader = "";
+        let alternateCell = "";
+        let altFLightlevel = "";
 
-        if (mcdu.winds.alternate != null) {
-            alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+        if (mcdu.altDestination) {
+            alternateHeader = "ALTN WIND";
+            alternateCell = "[ ]°/[ ][color]cyan";
+            altFLightlevel = "{green}{small}FL100{end}{end}";
+            if (mcdu.winds.alternate != null) {
+                alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+            }
         }
-
         const template = [
             ["DESCENT WIND"],
-            ["TRU WIND/ALT", "ALTN WIND"],
+            ["TRU WIND/ALT", alternateHeader],
             ["", alternateCell],
-            ["", "{green}{small}FL100{end}{end}"],
+            ["", altFLightlevel],
             ["", ""],
             ["", "WIND{sp}[color]amber"],
             ["", requestButton],
@@ -136,21 +142,23 @@ class CDUWindPage {
 
         mcdu.setTemplate(CDUWindPage.ShowWinds(template, mcdu, CDUWindPage.ShowDESPage, mcdu.winds.des, offset, 5));
 
-        mcdu.onRightInput[0] = (value, scratchpadCallback) => {
-            if (value == FMCMainDisplay.clrValue) {
-                mcdu.winds.alternate = null;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-                return;
-            }
-            const wind = CDUWindPage.ParseWind(value);
-            if (wind == null) {
-                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
-                scratchpadCallback();
-            } else {
-                mcdu.winds.alternate = wind;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-            }
-        };
+        if (mcdu.altDestination) {
+            mcdu.onRightInput[0] = (value, scratchpadCallback) => {
+                if (value == FMCMainDisplay.clrValue) {
+                    mcdu.winds.alternate = null;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                    return;
+                }
+                const wind = CDUWindPage.ParseWind(value);
+                if (wind == null) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                    scratchpadCallback();
+                } else {
+                    mcdu.winds.alternate = wind;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                }
+            };
+        }
 
         mcdu.onRightInput[3] = () => {
             CDUWindPage.ShowCRZPage(mcdu);
@@ -369,11 +377,14 @@ class CDUWindPage {
                     const tod = mcdu.simbrief.navlog.find((val) => val.ident === "TOD");
                     const desWpts = [tod, ...mcdu.simbrief.navlog.filter((val) => val.stage === stage)];
 
-                    mcdu.winds.alternate = {
-                        direction: mcdu.simbrief.alternateAvgWindDir,
-                        speed: mcdu.simbrief.alternateAvgWindSpd,
-                    };
-
+                    if (isFinite(mcdu.simbrief.alternateAvgWindDir) && isFinite(mcdu.simbrief.alternateAvgWindSpd)) {
+                        mcdu.winds.alternate = {
+                            direction: mcdu.simbrief.alternateAvgWindDir,
+                            speed: mcdu.simbrief.alternateAvgWindSpd,
+                        };
+                    } else {
+                        mcdu.winds.alternate = null;
+                    }
                     // iterate through each clbWpt grabbing the wind data
                     windData = [];
                     lastAltitude = 45000;

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a319-ceo/CDU/A320_Neo_CDU_WindPage.js
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a319-ceo/CDU/A320_Neo_CDU_WindPage.js
@@ -112,17 +112,23 @@ class CDUWindPage {
             requestButton = "REQUEST [color]amber";
         }
 
-        let alternateCell = "[ ]°/[ ][color]cyan";
+        let alternateHeader = "";
+        let alternateCell = "";
+        let altFLightlevel = "";
 
-        if (mcdu.winds.alternate != null) {
-            alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+        if (mcdu.altDestination) {
+            alternateHeader = "ALTN WIND";
+            alternateCell = "[ ]°/[ ][color]cyan";
+            altFLightlevel = "{green}{small}FL100{end}{end}";
+            if (mcdu.winds.alternate != null) {
+                alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+            }
         }
-
         const template = [
             ["DESCENT WIND"],
-            ["TRU WIND/ALT", "ALTN WIND"],
+            ["TRU WIND/ALT", alternateHeader],
             ["", alternateCell],
-            ["", "{green}{small}FL100{end}{end}"],
+            ["", altFLightlevel],
             ["", ""],
             ["", "WIND{sp}[color]amber"],
             ["", requestButton],
@@ -136,21 +142,23 @@ class CDUWindPage {
 
         mcdu.setTemplate(CDUWindPage.ShowWinds(template, mcdu, CDUWindPage.ShowDESPage, mcdu.winds.des, offset, 5));
 
-        mcdu.onRightInput[0] = (value, scratchpadCallback) => {
-            if (value == FMCMainDisplay.clrValue) {
-                mcdu.winds.alternate = null;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-                return;
-            }
-            const wind = CDUWindPage.ParseWind(value);
-            if (wind == null) {
-                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
-                scratchpadCallback();
-            } else {
-                mcdu.winds.alternate = wind;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-            }
-        };
+        if (mcdu.altDestination) {
+            mcdu.onRightInput[0] = (value, scratchpadCallback) => {
+                if (value == FMCMainDisplay.clrValue) {
+                    mcdu.winds.alternate = null;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                    return;
+                }
+                const wind = CDUWindPage.ParseWind(value);
+                if (wind == null) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                    scratchpadCallback();
+                } else {
+                    mcdu.winds.alternate = wind;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                }
+            };
+        }
 
         mcdu.onRightInput[3] = () => {
             CDUWindPage.ShowCRZPage(mcdu);
@@ -369,11 +377,14 @@ class CDUWindPage {
                     const tod = mcdu.simbrief.navlog.find((val) => val.ident === "TOD");
                     const desWpts = [tod, ...mcdu.simbrief.navlog.filter((val) => val.stage === stage)];
 
-                    mcdu.winds.alternate = {
-                        direction: mcdu.simbrief.alternateAvgWindDir,
-                        speed: mcdu.simbrief.alternateAvgWindSpd,
-                    };
-
+                    if (isFinite(mcdu.simbrief.alternateAvgWindDir) && isFinite(mcdu.simbrief.alternateAvgWindSpd)) {
+                        mcdu.winds.alternate = {
+                            direction: mcdu.simbrief.alternateAvgWindDir,
+                            speed: mcdu.simbrief.alternateAvgWindSpd,
+                        };
+                    } else {
+                        mcdu.winds.alternate = null;
+                    }
                     // iterate through each clbWpt grabbing the wind data
                     windData = [];
                     lastAltitude = 45000;

--- a/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a320-ceo/CDU/A320_Neo_CDU_WindPage.js
+++ b/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a320-ceo/CDU/A320_Neo_CDU_WindPage.js
@@ -112,17 +112,23 @@ class CDUWindPage {
             requestButton = "REQUEST [color]amber";
         }
 
-        let alternateCell = "[ ]°/[ ][color]cyan";
+        let alternateHeader = "";
+        let alternateCell = "";
+        let altFLightlevel = "";
 
-        if (mcdu.winds.alternate != null) {
-            alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+        if (mcdu.altDestination) {
+            alternateHeader = "ALTN WIND";
+            alternateCell = "[ ]°/[ ][color]cyan";
+            altFLightlevel = "{green}{small}FL100{end}{end}";
+            if (mcdu.winds.alternate != null) {
+                alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+            }
         }
-
         const template = [
             ["DESCENT WIND"],
-            ["TRU WIND/ALT", "ALTN WIND"],
+            ["TRU WIND/ALT", alternateHeader],
             ["", alternateCell],
-            ["", "{green}{small}FL100{end}{end}"],
+            ["", altFLightlevel],
             ["", ""],
             ["", "WIND{sp}[color]amber"],
             ["", requestButton],
@@ -136,21 +142,23 @@ class CDUWindPage {
 
         mcdu.setTemplate(CDUWindPage.ShowWinds(template, mcdu, CDUWindPage.ShowDESPage, mcdu.winds.des, offset, 5));
 
-        mcdu.onRightInput[0] = (value, scratchpadCallback) => {
-            if (value == FMCMainDisplay.clrValue) {
-                mcdu.winds.alternate = null;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-                return;
-            }
-            const wind = CDUWindPage.ParseWind(value);
-            if (wind == null) {
-                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
-                scratchpadCallback();
-            } else {
-                mcdu.winds.alternate = wind;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-            }
-        };
+        if (mcdu.altDestination) {
+            mcdu.onRightInput[0] = (value, scratchpadCallback) => {
+                if (value == FMCMainDisplay.clrValue) {
+                    mcdu.winds.alternate = null;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                    return;
+                }
+                const wind = CDUWindPage.ParseWind(value);
+                if (wind == null) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                    scratchpadCallback();
+                } else {
+                    mcdu.winds.alternate = wind;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                }
+            };
+        }
 
         mcdu.onRightInput[3] = () => {
             CDUWindPage.ShowCRZPage(mcdu);
@@ -369,11 +377,14 @@ class CDUWindPage {
                     const tod = mcdu.simbrief.navlog.find((val) => val.ident === "TOD");
                     const desWpts = [tod, ...mcdu.simbrief.navlog.filter((val) => val.stage === stage)];
 
-                    mcdu.winds.alternate = {
-                        direction: mcdu.simbrief.alternateAvgWindDir,
-                        speed: mcdu.simbrief.alternateAvgWindSpd,
-                    };
-
+                    if (isFinite(mcdu.simbrief.alternateAvgWindDir) && isFinite(mcdu.simbrief.alternateAvgWindSpd)) {
+                        mcdu.winds.alternate = {
+                            direction: mcdu.simbrief.alternateAvgWindDir,
+                            speed: mcdu.simbrief.alternateAvgWindSpd,
+                        };
+                    } else {
+                        mcdu.winds.alternate = null;
+                    }
                     // iterate through each clbWpt grabbing the wind data
                     windData = [];
                     lastAltitude = 45000;

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a321-neo/CDU/A320_Neo_CDU_WindPage.js
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/html_ui/Pages/VCockpit/Instruments/Airliners/lvfr-horizonsim-airbus-a321-neo/CDU/A320_Neo_CDU_WindPage.js
@@ -112,17 +112,23 @@ class CDUWindPage {
             requestButton = "REQUEST [color]amber";
         }
 
-        let alternateCell = "[ ]°/[ ][color]cyan";
+        let alternateHeader = "";
+        let alternateCell = "";
+        let altFLightlevel = "";
 
-        if (mcdu.winds.alternate != null) {
-            alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+        if (mcdu.altDestination) {
+            alternateHeader = "ALTN WIND";
+            alternateCell = "[ ]°/[ ][color]cyan";
+            altFLightlevel = "{green}{small}FL100{end}{end}";
+            if (mcdu.winds.alternate != null) {
+                alternateCell = `${CDUWindPage.FormatNumber(mcdu.winds.alternate.direction)}°/${CDUWindPage.FormatNumber(mcdu.winds.alternate.speed)}[color]cyan`;
+            }
         }
-
         const template = [
             ["DESCENT WIND"],
-            ["TRU WIND/ALT", "ALTN WIND"],
+            ["TRU WIND/ALT", alternateHeader],
             ["", alternateCell],
-            ["", "{green}{small}FL100{end}{end}"],
+            ["", altFLightlevel],
             ["", ""],
             ["", "WIND{sp}[color]amber"],
             ["", requestButton],
@@ -136,21 +142,23 @@ class CDUWindPage {
 
         mcdu.setTemplate(CDUWindPage.ShowWinds(template, mcdu, CDUWindPage.ShowDESPage, mcdu.winds.des, offset, 5));
 
-        mcdu.onRightInput[0] = (value, scratchpadCallback) => {
-            if (value == FMCMainDisplay.clrValue) {
-                mcdu.winds.alternate = null;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-                return;
-            }
-            const wind = CDUWindPage.ParseWind(value);
-            if (wind == null) {
-                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
-                scratchpadCallback();
-            } else {
-                mcdu.winds.alternate = wind;
-                CDUWindPage.ShowDESPage(mcdu, offset);
-            }
-        };
+        if (mcdu.altDestination) {
+            mcdu.onRightInput[0] = (value, scratchpadCallback) => {
+                if (value == FMCMainDisplay.clrValue) {
+                    mcdu.winds.alternate = null;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                    return;
+                }
+                const wind = CDUWindPage.ParseWind(value);
+                if (wind == null) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                    scratchpadCallback();
+                } else {
+                    mcdu.winds.alternate = wind;
+                    CDUWindPage.ShowDESPage(mcdu, offset);
+                }
+            };
+        }
 
         mcdu.onRightInput[3] = () => {
             CDUWindPage.ShowCRZPage(mcdu);
@@ -369,11 +377,14 @@ class CDUWindPage {
                     const tod = mcdu.simbrief.navlog.find((val) => val.ident === "TOD");
                     const desWpts = [tod, ...mcdu.simbrief.navlog.filter((val) => val.stage === stage)];
 
-                    mcdu.winds.alternate = {
-                        direction: mcdu.simbrief.alternateAvgWindDir,
-                        speed: mcdu.simbrief.alternateAvgWindSpd,
-                    };
-
+                    if (isFinite(mcdu.simbrief.alternateAvgWindDir) && isFinite(mcdu.simbrief.alternateAvgWindSpd)) {
+                        mcdu.winds.alternate = {
+                            direction: mcdu.simbrief.alternateAvgWindDir,
+                            speed: mcdu.simbrief.alternateAvgWindSpd,
+                        };
+                    } else {
+                        mcdu.winds.alternate = null;
+                    }
                     // iterate through each clbWpt grabbing the wind data
                     windData = [];
                     lastAltitude = 45000;


### PR DESCRIPTION
## Summary of Changes
Setting up a flight without an alternate I noticed that the ALTN winds where NaN. This was fixed in flybywiresim/aircraft#8129 but was missed in the HZ files.

Made sure the Wind pages for all the airplanes have change ported over.


Discord username: DeadBringer

## Testing instructions
Simbrief: Flight without ALTN
INIT A -> INIT REQUEST* ->  WIND/TEMP -> NEXT PHASE until DESCENT WIND page -> WIND REQUEST.
Before fix the ALT winds are NaN, after fix they should stay empty.
