### PR TITLE
Fixed - Pilot avatar now visible in the interior cockpit

### DIFF
--- a/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/SimObjects/Airplanes/A318ceoCFM/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/SimObjects/Airplanes/A318ceoCFM/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/SimObjects/Airplanes/A318cjCFM/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a318ceo/src/base/lvfr-horizonsim-airbus-a318-ceo/SimObjects/Airplanes/A318cjCFM/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a318ceo/src/model/models.json
+++ b/hsim-a318ceo/src/model/models.json
@@ -121,7 +121,7 @@
               1.0,
               1.0
             ],
-            "name": "CAPTAIN_AVATAR"
+            "name": "PILOT_0"
           },
           {
             "translation": [
@@ -140,7 +140,7 @@
               1.0,
               1.0
             ],
-            "name": "FIRSTOFFICER_AVATAR"
+            "name": "PILOT_1"
           }
         ]
       }

--- a/hsim-a318ceo/src/model/models.json
+++ b/hsim-a318ceo/src/model/models.json
@@ -101,7 +101,7 @@
       },
       {
         "combineFiles": [
-          "./a321-interior/A320_NEO_INTERIOR_LOD00.gltf"
+          "./a318-interior/A320_NEO_INTERIOR_LOD00.gltf"
         ],
         "nodes": [
           {

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFM/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFM/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFMSL/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFMSL/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFM_acj/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoCFM_acj/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoIAE/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoIAE/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoIAE_acj/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a319ceo/src/base/lvfr-horizonsim-airbus-a319-ceo/SimObjects/Airplanes/A319ceoIAE_acj/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a319ceo/src/model/models.json
+++ b/hsim-a319ceo/src/model/models.json
@@ -121,7 +121,7 @@
               1.0,
               1.0
             ],
-            "name": "CAPTAIN_AVATAR"
+            "name": "PILOT_0"
           },
           {
             "translation": [
@@ -140,7 +140,7 @@
               1.0,
               1.0
             ],
-            "name": "FIRSTOFFICER_AVATAR"
+            "name": "PILOT_1"
           }
         ]
       }

--- a/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoCFM/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoCFM/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoCFMsl/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoCFMsl/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoIAE/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoIAE/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoIAEsl/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a320ceo/src/base/lvfr-horizonsim-airbus-a320-ceo/SimObjects/Airplanes/A320ceoIAEsl/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a320ceo/src/model/models.json
+++ b/hsim-a320ceo/src/model/models.json
@@ -121,7 +121,7 @@
               1.0,
               1.0
             ],
-            "name": "CAPTAIN_AVATAR"
+            "name": "PILOT_0"
           },
           {
             "translation": [
@@ -140,7 +140,7 @@
               1.0,
               1.0
             ],
-            "name": "FIRSTOFFICER_AVATAR"
+            "name": "PILOT_1"
           }
         ]
       }

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/model.NACF/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/model.NACF/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrLEAP/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrLEAP/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrPW/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrPW/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/model.NACF/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/model.NACF/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/model/A320_NEO_INTERIOR.xml
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/model/A320_NEO_INTERIOR.xml
@@ -5243,7 +5243,7 @@
 
         <Component ID="Pilot_Avatars">
             <!-- Pilot -->
-            <Component ID="CAPTAIN_AVATAR" Node="CAPTAIN_AVATAR">
+            <Component ID="PILOT_0" Node="PILOT_0">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_0) (L:A32NX_PILOT_AVATAR_HIDDEN_0) ! and
@@ -5259,7 +5259,7 @@
                 </UseTemplate>
             </Component>
             <!-- First Officer -->
-            <Component ID="FIRSTOFFICER_AVATAR" Node="FIRSTOFFICER_AVATAR">
+            <Component ID="PILOT_1" Node="PILOT_1">
                 <UseTemplate Name="ASOBO_GT_Visibility_Code">
                     <VISIBILITY_CODE>
                         (L:A32NX_PILOT_AVATAR_VISIBLE_1) (L:A32NX_PILOT_AVATAR_HIDDEN_1) ! and

--- a/hsim-a321neo/src/model/models.json
+++ b/hsim-a321neo/src/model/models.json
@@ -126,7 +126,7 @@
               1.0,
               1.0
             ],
-            "name": "CAPTAIN_AVATAR"
+            "name": "PILOT_0"
           },
           {
             "translation": [
@@ -145,7 +145,7 @@
               1.0,
               1.0
             ],
-            "name": "FIRSTOFFICER_AVATAR"
+            "name": "PILOT_1"
           }
         ]
       }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

The issue is we cannot see the Pilot avatars in the interior cockpit, even though it's already enabled on EFB settings.

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Make the node name compatible with LVFR model, so now we can see the pilot avatars in the interior cockpit.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

- Set and enable the Captain and First Officer avatars cockpit visibility on the EFB "Realism" settings.
- Make sure you can see both avatars.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
