### PR TITLE
chore: upload releases yaml config to cdn for installer

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,6 +17,8 @@ jobs:
       PRE_RELEASE_TAG: vdev
       ZIP_NAME_A318: lvfr-horizonsim-airbus-a318-ceo-preview.zip
       BUILD_DIR_NAME: dev
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/stage
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -70,11 +72,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A318 }} ./lvfr-horizonsim-airbus-a318-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/stage
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN  
+        run: |
+          mkdir -p ./build-a318ceo/out/config
+          echo "releases:" >> ./build-a318ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a318ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a318ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -91,6 +97,8 @@ jobs:
       PRE_RELEASE_TAG: vdev
       ZIP_NAME_A319: lvfr-horizonsim-airbus-a319-ceo-preview.zip
       BUILD_DIR_NAME: dev
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/stage
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -144,11 +152,15 @@ jobs:
             zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A319 }} ./lvfr-horizonsim-airbus-a319-ceo/
             cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/stage
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN  
+        run: |
+          mkdir -p ./build-a319ceo/out/config
+          echo "releases:" >> ./build-a319ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a319ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a319ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -165,6 +177,8 @@ jobs:
       PRE_RELEASE_TAG: vdev
       ZIP_NAME_A320: lvfr-horizonsim-airbus-a320-ceo-preview.zip
       BUILD_DIR_NAME: dev
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/stage
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -218,11 +232,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A320 }} ./lvfr-horizonsim-airbus-a320-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/stage
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN  
+        run: |
+          mkdir -p ./build-a320ceo/out/config
+          echo "releases:" >> ./build-a320ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a320ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a320ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -239,6 +257,8 @@ jobs:
       PRE_RELEASE_TAG: vdev
       ZIP_NAME_A321: lvfr-horizonsim-airbus-a321-neo-preview.zip
       BUILD_DIR_NAME: dev
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/stage
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -292,11 +312,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A321 }} ./lvfr-horizonsim-airbus-a321-neo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/stage
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN  
+        run: |
+          mkdir -p ./build-a321neo/out/config
+          echo "releases:" >> ./build-a321neo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a321neo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a321neo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       PRE_RELEASE_TAG: vmain
       ZIP_NAME_A318: lvfr-horizonsim-airbus-a318-ceo.zip
       BUILD_DIR_NAME: main
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/development
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -67,11 +69,20 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A318 }} ./lvfr-horizonsim-airbus-a318-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/development
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/build-modules
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+      - name: Upload Release Config to CloudFlare CDN
+        env:
+          SHA: ${{ steps.short-sha.outputs.sha }}
+        run: |
+          mkdir -p ./build-a318ceo/out/config
+          echo "releases:" >> ./build-a318ceo/out/config/releases.yaml
+          echo "  - name: $SHA" >> ./build-a318ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a318ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -88,6 +99,8 @@ jobs:
       PRE_RELEASE_TAG: vmain
       ZIP_NAME_A319: lvfr-horizonsim-airbus-a319-ceo.zip
       BUILD_DIR_NAME: main
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/development
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -141,11 +154,20 @@ jobs:
             zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A319 }} ./lvfr-horizonsim-airbus-a319-ceo/
             cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/development
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/build-modules
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+      - name: Upload Release Config to CloudFlare CDN
+        env:
+          SHA: ${{ steps.short-sha.outputs.sha }}
+        run: |
+          mkdir -p ./build-a319ceo/out/config
+          echo "releases:" >> ./build-a319ceo/out/config/releases.yaml
+          echo "  - name: $SHA" >> ./build-a319ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a319ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -162,6 +184,8 @@ jobs:
       PRE_RELEASE_TAG: vmain
       ZIP_NAME_A320: lvfr-horizonsim-airbus-a320-ceo.zip
       BUILD_DIR_NAME: main
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/development
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -215,11 +239,20 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A320 }} ./lvfr-horizonsim-airbus-a320-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/development
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/build-modules
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+      - name: Upload Release Config to CloudFlare CDN
+        env:
+          SHA: ${{ steps.short-sha.outputs.sha }}
+        run: |
+          mkdir -p ./build-a320ceo/out/config
+          echo "releases:" >> ./build-a320ceo/out/config/releases.yaml
+          echo "  - name: $SHA" >> ./build-a320ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a320ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -236,6 +269,8 @@ jobs:
       PRE_RELEASE_TAG: vmain
       ZIP_NAME_A321: lvfr-horizonsim-airbus-a321-neo.zip
       BUILD_DIR_NAME: main
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/development
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -289,11 +324,20 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A321 }} ./lvfr-horizonsim-airbus-a321-neo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/development
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/build-modules
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+      - name: Upload Release Config to CloudFlare CDN
+        env:
+          SHA: ${{ steps.short-sha.outputs.sha }}
+        run: |
+          mkdir -p ./build-a321neo/out/config
+          echo "releases:" >> ./build-a321neo/out/config/releases.yaml
+          echo "  - name: $SHA" >> ./build-a321neo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a321neo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       PRE_RELEASE_TAG: vstable
       ZIP_NAME_A318: lvfr-horizonsim-airbus-a318-ceo-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: stable
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/release
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -70,11 +72,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A318 }} ./lvfr-horizonsim-airbus-a318-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a318ceo/release
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN
+        run: |
+          mkdir -p ./build-a318ceo/out/config
+          echo "releases:" >> ./build-a318ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a318ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a318ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a318ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -91,6 +97,8 @@ jobs:
       PRE_RELEASE_TAG: vstable
       ZIP_NAME_A319: lvfr-horizonsim-airbus-a319-ceo-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: stable
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/release
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -144,11 +152,15 @@ jobs:
             zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A319 }} ./lvfr-horizonsim-airbus-a319-ceo/
             cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a319ceo/release
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN
+        run: |
+          mkdir -p ./build-a319ceo/out/config
+          echo "releases:" >> ./build-a319ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a319ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a319ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a319ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -165,6 +177,8 @@ jobs:
       PRE_RELEASE_TAG: vstable
       ZIP_NAME_A320: lvfr-horizonsim-airbus-a320-ceo-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: stable
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/release
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -218,11 +232,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A320 }} ./lvfr-horizonsim-airbus-a320-ceo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a320ceo/release
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN
+        run: |
+          mkdir -p ./build-a320ceo/out/config
+          echo "releases:" >> ./build-a320ceo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a320ceo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a320ceo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a320ceo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:
@@ -239,6 +257,8 @@ jobs:
       PRE_RELEASE_TAG: vstable
       ZIP_NAME_A321: lvfr-horizonsim-airbus-a321-neo-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: stable
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/release
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -292,11 +312,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME_A321 }} ./lvfr-horizonsim-airbus-a321-neo/
           cd ../../
       - name: Upload to CloudFlare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/lvfr-a321neo/release
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/build-modules
+      - name: Upload Release Config to CloudFlare CDN
+        run: |
+          mkdir -p ./build-a321neo/out/config
+          echo "releases:" >> ./build-a321neo/out/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./build-a321neo/out/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./build-a321neo/out/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./build-a321neo/out/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:


### PR DESCRIPTION
Create a `releases.yaml` file which will be used by the headwind installer for information to make github api request call obsolete / minimize them.