### PR TITLE
correction strobe and landing light

### DIFF
--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/systems.cfg
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/A321neoLEAP/systems.cfg
@@ -67,88 +67,88 @@ lightdef.2 = Type:3#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile
 lightdef.3 = Type:3#Index:4#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_NavigationWhite#Node:LIGHT_ASOBO_NavigationTailLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_NavigationTailLeft     ; NAV TAIL L WHITE
 
 ; BEACON LT
-lightdef.4 = 
-lightdef.5 = 
+lightdef.4 =
+lightdef.5 =
 lightdef.6 = Type:1#Index:1#LocalPosition:-11.5,0,11.75#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconTop#Node:LIGHT_ASOBO_BeaconTop#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconTop              ; TOP AMB
-lightdef.7 = 
-lightdef.8 = 
+lightdef.7 =
+lightdef.8 =
 lightdef.9 = Type:1#Index:2#LocalPosition:-3.4,0,-3.1#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconBelly#Node:LIGHT_ASOBO_BeaconBelly#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconBelly   ; BELLY C GND
-lightdef.10 = 
-lightdef.11 = 
-lightdef.12 = 
-lightdef.13 = 
-lightdef.14 = 
-lightdef.15 = 
-lightdef.16 = 
-lightdef.17 = 
+lightdef.10 =
+lightdef.11 =
+lightdef.12 =
+lightdef.13 =
+lightdef.14 =
+lightdef.15 =
+lightdef.16 =
+lightdef.17 =
 
 ; STROBE LT
-lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
+lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
 lightdef.19 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftInner       ; STROBE L IN
-lightdef.20 = 
-lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
+lightdef.20 =
+lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
 lightdef.22 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,-70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightInner    ; STROBE R IN
-lightdef.23 = 
+lightdef.23 =
 lightdef.24 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_StrobeSimple#Node:LIGHT_ASOBO_StrobeTail#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeTail                        ; STROBE TAIL
 
 ; LOGO LT L/R
 lightdef.25 = Type:9#Index:1#LocalPosition:0,0,0#LocalRotation:-70,0,-60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoLeft      ; LOGO L
-lightdef.26 = 
-lightdef.27 = 
+lightdef.26 =
+lightdef.27 =
 lightdef.28 = Type:9#Index:2#LocalPosition:0,0,0#LocalRotation:-70,0,60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoRight     ; LOGO R
-lightdef.29 = 
-lightdef.30 = 
+lightdef.29 =
+lightdef.30 =
 
 ; TAXI/T/O LT
 lightdef.31 = Type:6#Index:1#LocalPosition:27.5,0.5,-2.4#LocalRotation:0,0,0#EffectFile:NL-HS-A321_TaxiLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_Taxi            ; TAXI LT
-lightdef.32 = 
-lightdef.33 = 
-lightdef.34 = 
-lightdef.35 = 
+lightdef.32 =
+lightdef.33 =
+lightdef.34 =
+lightdef.35 =
 lightdef.36 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff        ; T/O LT
 lightdef.37 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff+#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff
-lightdef.38 = 
-lightdef.39 = 
-lightdef.40 = 
+lightdef.38 =
+lightdef.39 =
+lightdef.40 =
 
 ; RW TURN OFF LT
 lightdef.41 = Type:6#Index:2#LocalPosition:27.5,0.7,-4.4#LocalRotation:0,180,-45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffLeft         ; RWY TURN OFF L
-lightdef.42 = 
-lightdef.43 = 
-lightdef.44 = 
+lightdef.42 =
+lightdef.43 =
+lightdef.44 =
 lightdef.45 = Type:6#Index:3#LocalPosition:27.5,-0.7,-4.4#LocalRotation:0,180,45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffRight      ; RWY TURN OFF R
-lightdef.46 = 
-lightdef.47 = 
-lightdef.48 = 
-lightdef.49 = 
+lightdef.46 =
+lightdef.47 =
+lightdef.48 =
+lightdef.49 =
 
 ; LANDING LT
-lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.52 = 
-lightdef.53 = 
-lightdef.54 = 
-lightdef.55 = 
-lightdef.56 = 
-lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.59 = 
-lightdef.60 = 
-lightdef.61 = 
-lightdef.62 = 
-lightdef.63 = 
+lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.52 =
+lightdef.53 =
+lightdef.54 =
+lightdef.55 =
+lightdef.56 =
+lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.59 =
+lightdef.60 =
+lightdef.61 =
+lightdef.62 =
+lightdef.63 =
 
 ; WING LT
 lightdef.64 = Type:8#Index:1#LocalPosition:15.57,-6.5,4.58#LocalRotation:2,0,145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingLeft      ; WING LT L
-lightdef.65 = 
-lightdef.66 =																																														  
-lightdef.67 = 
+lightdef.65 =
+lightdef.66 =
+lightdef.67 =
 lightdef.68 =
 lightdef.69 = Type:8#Index:2#LocalPosition:15.57,6.5,4.58#LocalRotation:2,0,-145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingRight     ; WING LT R
-																																																	   
+
 lightdef.70 =
-lightdef.71 =																																																	  
-lightdef.72 =																																																 
+lightdef.71 =
+lightdef.72 =
 lightdef.73 =
 
 
@@ -164,16 +164,18 @@ lightdef.77 = Type:4#Index:8#LocalPosition:35,0,8.3#LocalRotation:80,0,0#EffectF
 lightdef.78 = Type:4#Index:8#LocalPosition:33.8,1.5,9.9#LocalRotation:110,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientOverhead#PotentiometerIndex:86           				; OVHD AMB CB
 
 ; FCU INTEG LT AMBIENT
-lightdef.79 = Type:12#Index:5#LocalPosition:38.52,-0.9,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
-lightdef.80 = Type:12#Index:5#LocalPosition:38.52,-0.740,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
-lightdef.81 = Type:12#Index:5#LocalPosition:38.52,-0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
-lightdef.82 = Type:12#Index:5#LocalPosition:38.52,-0.33,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
-lightdef.83 = Type:12#Index:5#LocalPosition:38.52,-0.18,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
-lightdef.84 = Type:12#Index:5#LocalPosition:38.52,0.170,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
-lightdef.85 = Type:12#Index:5#LocalPosition:38.52,0.35,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
-lightdef.86 = Type:12#Index:5#LocalPosition:38.52,0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
-lightdef.87 = Type:12#Index:5#LocalPosition:38.52,0.74,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
-lightdef.88 = Type:12#Index:5#LocalPosition:38.52,0.90,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
+lightdef.79 = Type:12#Index:5#LocalPosition:38.3775,-0.907405,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.80 = Type:0#Index:5#LocalPosition:38.3775,-0.738063,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
+lightdef.81 = Type:0#Index:5#LocalPosition:38.3775,-0.559805,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
+lightdef.82 = Type:12#Index:5#LocalPosition:38.3775,-0.329049,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
+lightdef.83 = Type:12#Index:5#LocalPosition:38.3775,-0.180246,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
+lightdef.84 = Type:12#Index:5#LocalPosition:38.3775,0.159389,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
+lightdef.85 = Type:12#Index:5#LocalPosition:38.3775,0.346189,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.86 = Type:0#Index:5#LocalPosition:38.3775,0.553744,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
+lightdef.87 = Type:0#Index:5#LocalPosition:38.3775,0.732994,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
+lightdef.88 = Type:12#Index:5#LocalPosition:38.3775,0.902528,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
 
 ; PEDESTAL INTEG LT AMBIENT
 lightdef.89 = Type:4#Index:7#LocalPosition:38.60,-0.260,4.40#LocalRotation:-10,0,180#EffectFile:A32NX_Cockpit_EmissiveAmbientPedSwitches#PotentiometerIndex:85     			; PED MID SWITCHES 1
@@ -228,8 +230,8 @@ lightdef.131 = Type:12#Index:3#LocalPosition:38.6,0,4.6#LocalRotation:0,0,0#Effe
 lightdef.132 = Type:12#Index:4#LocalPosition:38.4,2.58,4.59#LocalRotation:0,0,0#EffectFile:A32NX_Cockpit_MainPanelFloodAmbientEnd#PotentiometerIndex:83   					; F/O AMB
 
 ; CPT / F/O TABLE LT
-lightdef.133 = Type:12#Index:1#LocalPosition:38.5,-1.825,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
-lightdef.134 = Type:12#Index:2#LocalPosition:38.5,1.76,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
+lightdef.133 = Type:12#Index:1#LocalPosition:38.414,-1.843,5.955#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
+lightdef.134 = Type:12#Index:2#LocalPosition:38.407,1.841,5.965#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
 
 ; CTP / F/O CONSOLE/FLOOR LT
 lightdef.135 = Type:4#Index:3#LocalPosition:37.4,-3.67,5.4#LocalRotation:90,0,70#EffectFile:A32NX_Cockpit_Console#PotentiometerIndex:8  									; CONSOLE/FLOOR LT CPT 1
@@ -516,6 +518,7 @@ stick_shaker = 1
 
 [DEICE_SYSTEM]
 structural_deice_type = 1 ; 0 = None, 1 = Heated Leading Edge, 2 = Bleed Air Boots, 3 = Eng Pump Boots
+windshield_deice_rate = 0.033 ; Pct reduction of ice per second -- Clears windshield of ice in 30 seconds
 
 [RADIOS]
 Audio.1 = 1

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrLEAP/systems.cfg
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrLEAP/systems.cfg
@@ -67,88 +67,88 @@ lightdef.2 = Type:3#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile
 lightdef.3 = Type:3#Index:4#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_NavigationWhite#Node:LIGHT_ASOBO_NavigationTailLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_NavigationTailLeft     ; NAV TAIL L WHITE
 
 ; BEACON LT
-lightdef.4 = 
-lightdef.5 = 
+lightdef.4 =
+lightdef.5 =
 lightdef.6 = Type:1#Index:1#LocalPosition:-11.5,0,11.75#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconTop#Node:LIGHT_ASOBO_BeaconTop#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconTop              ; TOP AMB
-lightdef.7 = 
-lightdef.8 = 
+lightdef.7 =
+lightdef.8 =
 lightdef.9 = Type:1#Index:2#LocalPosition:-3.4,0,-3.1#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconBelly#Node:LIGHT_ASOBO_BeaconBelly#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconBelly   ; BELLY C GND
-lightdef.10 = 
-lightdef.11 = 
-lightdef.12 = 
-lightdef.13 = 
-lightdef.14 = 
-lightdef.15 = 
-lightdef.16 = 
-lightdef.17 = 
+lightdef.10 =
+lightdef.11 =
+lightdef.12 =
+lightdef.13 =
+lightdef.14 =
+lightdef.15 =
+lightdef.16 =
+lightdef.17 =
 
 ; STROBE LT
-lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
+lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
 lightdef.19 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftInner       ; STROBE L IN
-lightdef.20 = 
-lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
+lightdef.20 =
+lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
 lightdef.22 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,-70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightInner    ; STROBE R IN
-lightdef.23 = 
+lightdef.23 =
 lightdef.24 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_StrobeSimple#Node:LIGHT_ASOBO_StrobeTail#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeTail                        ; STROBE TAIL
 
 ; LOGO LT L/R
 lightdef.25 = Type:9#Index:1#LocalPosition:0,0,0#LocalRotation:-70,0,-60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoLeft      ; LOGO L
-lightdef.26 = 
-lightdef.27 = 
+lightdef.26 =
+lightdef.27 =
 lightdef.28 = Type:9#Index:2#LocalPosition:0,0,0#LocalRotation:-70,0,60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoRight     ; LOGO R
-lightdef.29 = 
-lightdef.30 = 
+lightdef.29 =
+lightdef.30 =
 
 ; TAXI/T/O LT
 lightdef.31 = Type:6#Index:1#LocalPosition:27.5,0.5,-2.4#LocalRotation:0,0,0#EffectFile:NL-HS-A321_TaxiLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_Taxi            ; TAXI LT
-lightdef.32 = 
-lightdef.33 = 
-lightdef.34 = 
-lightdef.35 = 
+lightdef.32 =
+lightdef.33 =
+lightdef.34 =
+lightdef.35 =
 lightdef.36 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff        ; T/O LT
 lightdef.37 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff+#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff
-lightdef.38 = 
-lightdef.39 = 
-lightdef.40 = 
+lightdef.38 =
+lightdef.39 =
+lightdef.40 =
 
 ; RW TURN OFF LT
 lightdef.41 = Type:6#Index:2#LocalPosition:27.5,0.7,-4.4#LocalRotation:0,180,-45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffLeft         ; RWY TURN OFF L
-lightdef.42 = 
-lightdef.43 = 
-lightdef.44 = 
+lightdef.42 =
+lightdef.43 =
+lightdef.44 =
 lightdef.45 = Type:6#Index:3#LocalPosition:27.5,-0.7,-4.4#LocalRotation:0,180,45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffRight      ; RWY TURN OFF R
-lightdef.46 = 
-lightdef.47 = 
-lightdef.48 = 
-lightdef.49 = 
+lightdef.46 =
+lightdef.47 =
+lightdef.48 =
+lightdef.49 =
 
 ; LANDING LT
-lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.52 = 
-lightdef.53 = 
-lightdef.54 = 
-lightdef.55 = 
-lightdef.56 = 
-lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.59 = 
-lightdef.60 = 
-lightdef.61 = 
-lightdef.62 = 
-lightdef.63 = 
+lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.52 =
+lightdef.53 =
+lightdef.54 =
+lightdef.55 =
+lightdef.56 =
+lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.59 =
+lightdef.60 =
+lightdef.61 =
+lightdef.62 =
+lightdef.63 =
 
 ; WING LT
 lightdef.64 = Type:8#Index:1#LocalPosition:15.57,-6.5,4.58#LocalRotation:2,0,145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingLeft      ; WING LT L
-lightdef.65 = 
-lightdef.66 =																																														  
-lightdef.67 = 
+lightdef.65 =
+lightdef.66 =
+lightdef.67 =
 lightdef.68 =
 lightdef.69 = Type:8#Index:2#LocalPosition:15.57,6.5,4.58#LocalRotation:2,0,-145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingRight     ; WING LT R
-																																																	   
+
 lightdef.70 =
-lightdef.71 =																																																	  
-lightdef.72 =																																																 
+lightdef.71 =
+lightdef.72 =
 lightdef.73 =
 
 
@@ -164,16 +164,18 @@ lightdef.77 = Type:4#Index:8#LocalPosition:35,0,8.3#LocalRotation:80,0,0#EffectF
 lightdef.78 = Type:4#Index:8#LocalPosition:33.8,1.5,9.9#LocalRotation:110,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientOverhead#PotentiometerIndex:86           				; OVHD AMB CB
 
 ; FCU INTEG LT AMBIENT
-lightdef.79 = Type:12#Index:5#LocalPosition:38.52,-0.9,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
-lightdef.80 = Type:12#Index:5#LocalPosition:38.52,-0.740,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
-lightdef.81 = Type:12#Index:5#LocalPosition:38.52,-0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
-lightdef.82 = Type:12#Index:5#LocalPosition:38.52,-0.33,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
-lightdef.83 = Type:12#Index:5#LocalPosition:38.52,-0.18,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
-lightdef.84 = Type:12#Index:5#LocalPosition:38.52,0.170,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
-lightdef.85 = Type:12#Index:5#LocalPosition:38.52,0.35,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
-lightdef.86 = Type:12#Index:5#LocalPosition:38.52,0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
-lightdef.87 = Type:12#Index:5#LocalPosition:38.52,0.74,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
-lightdef.88 = Type:12#Index:5#LocalPosition:38.52,0.90,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
+lightdef.79 = Type:12#Index:5#LocalPosition:38.3775,-0.907405,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.80 = Type:0#Index:5#LocalPosition:38.3775,-0.738063,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
+lightdef.81 = Type:0#Index:5#LocalPosition:38.3775,-0.559805,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
+lightdef.82 = Type:12#Index:5#LocalPosition:38.3775,-0.329049,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
+lightdef.83 = Type:12#Index:5#LocalPosition:38.3775,-0.180246,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
+lightdef.84 = Type:12#Index:5#LocalPosition:38.3775,0.159389,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
+lightdef.85 = Type:12#Index:5#LocalPosition:38.3775,0.346189,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.86 = Type:0#Index:5#LocalPosition:38.3775,0.553744,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
+lightdef.87 = Type:0#Index:5#LocalPosition:38.3775,0.732994,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
+lightdef.88 = Type:12#Index:5#LocalPosition:38.3775,0.902528,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
 
 ; PEDESTAL INTEG LT AMBIENT
 lightdef.89 = Type:4#Index:7#LocalPosition:38.60,-0.260,4.40#LocalRotation:-10,0,180#EffectFile:A32NX_Cockpit_EmissiveAmbientPedSwitches#PotentiometerIndex:85     			; PED MID SWITCHES 1
@@ -228,8 +230,8 @@ lightdef.131 = Type:12#Index:3#LocalPosition:38.6,0,4.6#LocalRotation:0,0,0#Effe
 lightdef.132 = Type:12#Index:4#LocalPosition:38.4,2.58,4.59#LocalRotation:0,0,0#EffectFile:A32NX_Cockpit_MainPanelFloodAmbientEnd#PotentiometerIndex:83   					; F/O AMB
 
 ; CPT / F/O TABLE LT
-lightdef.133 = Type:12#Index:1#LocalPosition:38.5,-1.825,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
-lightdef.134 = Type:12#Index:2#LocalPosition:38.5,1.76,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
+lightdef.133 = Type:12#Index:1#LocalPosition:38.414,-1.843,5.955#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
+lightdef.134 = Type:12#Index:2#LocalPosition:38.407,1.841,5.965#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
 
 ; CTP / F/O CONSOLE/FLOOR LT
 lightdef.135 = Type:4#Index:3#LocalPosition:37.4,-3.67,5.4#LocalRotation:90,0,70#EffectFile:A32NX_Cockpit_Console#PotentiometerIndex:8  									; CONSOLE/FLOOR LT CPT 1
@@ -516,6 +518,7 @@ stick_shaker = 1
 
 [DEICE_SYSTEM]
 structural_deice_type = 1 ; 0 = None, 1 = Heated Leading Edge, 2 = Bleed Air Boots, 3 = Eng Pump Boots
+windshield_deice_rate = 0.033 ; Pct reduction of ice per second -- Clears windshield of ice in 30 seconds
 
 [RADIOS]
 Audio.1 = 1

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrPW/systems.cfg
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neolrPW/systems.cfg
@@ -67,88 +67,88 @@ lightdef.2 = Type:3#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile
 lightdef.3 = Type:3#Index:4#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_NavigationWhite#Node:LIGHT_ASOBO_NavigationTailLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_NavigationTailLeft     ; NAV TAIL L WHITE
 
 ; BEACON LT
-lightdef.4 = 
-lightdef.5 = 
+lightdef.4 =
+lightdef.5 =
 lightdef.6 = Type:1#Index:1#LocalPosition:-11.5,0,11.75#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconTop#Node:LIGHT_ASOBO_BeaconTop#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconTop              ; TOP AMB
-lightdef.7 = 
-lightdef.8 = 
+lightdef.7 =
+lightdef.8 =
 lightdef.9 = Type:1#Index:2#LocalPosition:-3.4,0,-3.1#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconBelly#Node:LIGHT_ASOBO_BeaconBelly#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconBelly   ; BELLY C GND
-lightdef.10 = 
-lightdef.11 = 
-lightdef.12 = 
-lightdef.13 = 
-lightdef.14 = 
-lightdef.15 = 
-lightdef.16 = 
-lightdef.17 = 
+lightdef.10 =
+lightdef.11 =
+lightdef.12 =
+lightdef.13 =
+lightdef.14 =
+lightdef.15 =
+lightdef.16 =
+lightdef.17 =
 
 ; STROBE LT
-lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
+lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
 lightdef.19 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftInner       ; STROBE L IN
-lightdef.20 = 
-lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
+lightdef.20 =
+lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
 lightdef.22 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,-70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightInner    ; STROBE R IN
-lightdef.23 = 
+lightdef.23 =
 lightdef.24 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_StrobeSimple#Node:LIGHT_ASOBO_StrobeTail#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeTail                        ; STROBE TAIL
 
 ; LOGO LT L/R
 lightdef.25 = Type:9#Index:1#LocalPosition:0,0,0#LocalRotation:-70,0,-60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoLeft      ; LOGO L
-lightdef.26 = 
-lightdef.27 = 
+lightdef.26 =
+lightdef.27 =
 lightdef.28 = Type:9#Index:2#LocalPosition:0,0,0#LocalRotation:-70,0,60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoRight     ; LOGO R
-lightdef.29 = 
-lightdef.30 = 
+lightdef.29 =
+lightdef.30 =
 
 ; TAXI/T/O LT
 lightdef.31 = Type:6#Index:1#LocalPosition:27.5,0.5,-2.4#LocalRotation:0,0,0#EffectFile:NL-HS-A321_TaxiLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_Taxi            ; TAXI LT
-lightdef.32 = 
-lightdef.33 = 
-lightdef.34 = 
-lightdef.35 = 
+lightdef.32 =
+lightdef.33 =
+lightdef.34 =
+lightdef.35 =
 lightdef.36 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff        ; T/O LT
 lightdef.37 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff+#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff
-lightdef.38 = 
-lightdef.39 = 
-lightdef.40 = 
+lightdef.38 =
+lightdef.39 =
+lightdef.40 =
 
 ; RW TURN OFF LT
 lightdef.41 = Type:6#Index:2#LocalPosition:27.5,0.7,-4.4#LocalRotation:0,180,-45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffLeft         ; RWY TURN OFF L
-lightdef.42 = 
-lightdef.43 = 
-lightdef.44 = 
+lightdef.42 =
+lightdef.43 =
+lightdef.44 =
 lightdef.45 = Type:6#Index:3#LocalPosition:27.5,-0.7,-4.4#LocalRotation:0,180,45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffRight      ; RWY TURN OFF R
-lightdef.46 = 
-lightdef.47 = 
-lightdef.48 = 
-lightdef.49 = 
+lightdef.46 =
+lightdef.47 =
+lightdef.48 =
+lightdef.49 =
 
 ; LANDING LT
-lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.52 = 
-lightdef.53 = 
-lightdef.54 = 
-lightdef.55 = 
-lightdef.56 = 
-lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.59 = 
-lightdef.60 = 
-lightdef.61 = 
-lightdef.62 = 
-lightdef.63 = 
+lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.52 =
+lightdef.53 =
+lightdef.54 =
+lightdef.55 =
+lightdef.56 =
+lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.59 =
+lightdef.60 =
+lightdef.61 =
+lightdef.62 =
+lightdef.63 =
 
 ; WING LT
 lightdef.64 = Type:8#Index:1#LocalPosition:15.57,-6.5,4.58#LocalRotation:2,0,145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingLeft      ; WING LT L
-lightdef.65 = 
-lightdef.66 =																																														  
-lightdef.67 = 
+lightdef.65 =
+lightdef.66 =
+lightdef.67 =
 lightdef.68 =
 lightdef.69 = Type:8#Index:2#LocalPosition:15.57,6.5,4.58#LocalRotation:2,0,-145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingRight     ; WING LT R
-																																																	   
+
 lightdef.70 =
-lightdef.71 =																																																	  
-lightdef.72 =																																																 
+lightdef.71 =
+lightdef.72 =
 lightdef.73 =
 
 
@@ -164,16 +164,18 @@ lightdef.77 = Type:4#Index:8#LocalPosition:35,0,8.3#LocalRotation:80,0,0#EffectF
 lightdef.78 = Type:4#Index:8#LocalPosition:33.8,1.5,9.9#LocalRotation:110,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientOverhead#PotentiometerIndex:86           				; OVHD AMB CB
 
 ; FCU INTEG LT AMBIENT
-lightdef.79 = Type:12#Index:5#LocalPosition:38.52,-0.9,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
-lightdef.80 = Type:12#Index:5#LocalPosition:38.52,-0.740,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
-lightdef.81 = Type:12#Index:5#LocalPosition:38.52,-0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
-lightdef.82 = Type:12#Index:5#LocalPosition:38.52,-0.33,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
-lightdef.83 = Type:12#Index:5#LocalPosition:38.52,-0.18,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
-lightdef.84 = Type:12#Index:5#LocalPosition:38.52,0.170,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
-lightdef.85 = Type:12#Index:5#LocalPosition:38.52,0.35,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
-lightdef.86 = Type:12#Index:5#LocalPosition:38.52,0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
-lightdef.87 = Type:12#Index:5#LocalPosition:38.52,0.74,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
-lightdef.88 = Type:12#Index:5#LocalPosition:38.52,0.90,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
+lightdef.79 = Type:12#Index:5#LocalPosition:38.3775,-0.907405,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.80 = Type:0#Index:5#LocalPosition:38.3775,-0.738063,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
+lightdef.81 = Type:0#Index:5#LocalPosition:38.3775,-0.559805,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
+lightdef.82 = Type:12#Index:5#LocalPosition:38.3775,-0.329049,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
+lightdef.83 = Type:12#Index:5#LocalPosition:38.3775,-0.180246,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
+lightdef.84 = Type:12#Index:5#LocalPosition:38.3775,0.159389,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
+lightdef.85 = Type:12#Index:5#LocalPosition:38.3775,0.346189,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.86 = Type:0#Index:5#LocalPosition:38.3775,0.553744,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
+lightdef.87 = Type:0#Index:5#LocalPosition:38.3775,0.732994,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
+lightdef.88 = Type:12#Index:5#LocalPosition:38.3775,0.902528,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
 
 ; PEDESTAL INTEG LT AMBIENT
 lightdef.89 = Type:4#Index:7#LocalPosition:38.60,-0.260,4.40#LocalRotation:-10,0,180#EffectFile:A32NX_Cockpit_EmissiveAmbientPedSwitches#PotentiometerIndex:85     			; PED MID SWITCHES 1
@@ -228,8 +230,8 @@ lightdef.131 = Type:12#Index:3#LocalPosition:38.6,0,4.6#LocalRotation:0,0,0#Effe
 lightdef.132 = Type:12#Index:4#LocalPosition:38.4,2.58,4.59#LocalRotation:0,0,0#EffectFile:A32NX_Cockpit_MainPanelFloodAmbientEnd#PotentiometerIndex:83   					; F/O AMB
 
 ; CPT / F/O TABLE LT
-lightdef.133 = Type:12#Index:1#LocalPosition:38.5,-1.825,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
-lightdef.134 = Type:12#Index:2#LocalPosition:38.5,1.76,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
+lightdef.133 = Type:12#Index:1#LocalPosition:38.414,-1.843,5.955#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
+lightdef.134 = Type:12#Index:2#LocalPosition:38.407,1.841,5.965#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
 
 ; CTP / F/O CONSOLE/FLOOR LT
 lightdef.135 = Type:4#Index:3#LocalPosition:37.4,-3.67,5.4#LocalRotation:90,0,70#EffectFile:A32NX_Cockpit_Console#PotentiometerIndex:8  									; CONSOLE/FLOOR LT CPT 1
@@ -516,6 +518,7 @@ stick_shaker = 1
 
 [DEICE_SYSTEM]
 structural_deice_type = 1 ; 0 = None, 1 = Heated Leading Edge, 2 = Bleed Air Boots, 3 = Eng Pump Boots
+windshield_deice_rate = 0.033 ; Pct reduction of ice per second -- Clears windshield of ice in 30 seconds
 
 [RADIOS]
 Audio.1 = 1

--- a/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/systems.cfg
+++ b/hsim-a321neo/src/base/lvfr-horizonsim-airbus-a321-neo/SimObjects/Airplanes/aircrafta321neopw/systems.cfg
@@ -67,88 +67,88 @@ lightdef.2 = Type:3#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile
 lightdef.3 = Type:3#Index:4#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_NavigationWhite#Node:LIGHT_ASOBO_NavigationTailLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_NavigationTailLeft     ; NAV TAIL L WHITE
 
 ; BEACON LT
-lightdef.4 = 
-lightdef.5 = 
+lightdef.4 =
+lightdef.5 =
 lightdef.6 = Type:1#Index:1#LocalPosition:-11.5,0,11.75#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconTop#Node:LIGHT_ASOBO_BeaconTop#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconTop              ; TOP AMB
-lightdef.7 = 
-lightdef.8 = 
+lightdef.7 =
+lightdef.8 =
 lightdef.9 = Type:1#Index:2#LocalPosition:-3.4,0,-3.1#LocalRotation:0,0,0#EffectFile:NL-HS-A321_BeaconBelly#Node:LIGHT_ASOBO_BeaconBelly#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_BeaconBelly   ; BELLY C GND
-lightdef.10 = 
-lightdef.11 = 
-lightdef.12 = 
-lightdef.13 = 
-lightdef.14 = 
-lightdef.15 = 
-lightdef.16 = 
-lightdef.17 = 
+lightdef.10 =
+lightdef.11 =
+lightdef.12 =
+lightdef.13 =
+lightdef.14 =
+lightdef.15 =
+lightdef.16 =
+lightdef.17 =
 
 ; STROBE LT
-lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
+lightdef.18 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftOuter       ; STROBE L OUT
 lightdef.19 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstrobeleftnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingLeftInner       ; STROBE L IN
-lightdef.20 = 
-lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-20#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
+lightdef.20 =
+lightdef.21 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,-30#EffectFile:NL-HS-A321_Strobedouble#Node:outerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightOuter    ; STROBE R OUT
 lightdef.22 = Type:2#Index:3#LocalPosition:0,0,0#LocalRotation:0,0,-70#EffectFile:NL-HS-A321_Strobedouble#Node:Innerstroberightnode#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeWingRightInner    ; STROBE R IN
-lightdef.23 = 
+lightdef.23 =
 lightdef.24 = Type:2#Index:0#LocalPosition:0,0,0#LocalRotation:0,0,180#EffectFile:NL-HS-A321_StrobeSimple#Node:LIGHT_ASOBO_StrobeTail#PotentiometerIndex:24#EmMesh:LIGHT_ASOBO_StrobeTail                        ; STROBE TAIL
 
 ; LOGO LT L/R
 lightdef.25 = Type:9#Index:1#LocalPosition:0,0,0#LocalRotation:-70,0,-60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoLeft      ; LOGO L
-lightdef.26 = 
-lightdef.27 = 
+lightdef.26 =
+lightdef.27 =
 lightdef.28 = Type:9#Index:2#LocalPosition:0,0,0#LocalRotation:-70,0,60#EffectFile:NL-HS-A321_LogoLightLarge#Node:LIGHT_ASOBO_LogoRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LogoRight     ; LOGO R
-lightdef.29 = 
-lightdef.30 = 
+lightdef.29 =
+lightdef.30 =
 
 ; TAXI/T/O LT
 lightdef.31 = Type:6#Index:1#LocalPosition:27.5,0.5,-2.4#LocalRotation:0,0,0#EffectFile:NL-HS-A321_TaxiLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_Taxi            ; TAXI LT
-lightdef.32 = 
-lightdef.33 = 
-lightdef.34 = 
-lightdef.35 = 
+lightdef.32 =
+lightdef.33 =
+lightdef.34 =
+lightdef.35 =
 lightdef.36 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff        ; T/O LT
 lightdef.37 = Type:5#Index:1#LocalPosition:27.5,-0.5,-2.4#LocalRotation:-5,0,0#EffectFile:NL-HS-A321_TakeOff+#Node:LIGHT_ASOBO_TakeOff#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_TakeOff
-lightdef.38 = 
-lightdef.39 = 
-lightdef.40 = 
+lightdef.38 =
+lightdef.39 =
+lightdef.40 =
 
 ; RW TURN OFF LT
 lightdef.41 = Type:6#Index:2#LocalPosition:27.5,0.7,-4.4#LocalRotation:0,180,-45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffLeft#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffLeft         ; RWY TURN OFF L
-lightdef.42 = 
-lightdef.43 = 
-lightdef.44 = 
+lightdef.42 =
+lightdef.43 =
+lightdef.44 =
 lightdef.45 = Type:6#Index:3#LocalPosition:27.5,-0.7,-4.4#LocalRotation:0,180,45#EffectFile:NL-HS-A321_turnoff#Node:LIGHT_ASOBO_RunwayTurnOffRight#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_RunwayTurnOffRight      ; RWY TURN OFF R
-lightdef.46 = 
-lightdef.47 = 
-lightdef.48 = 
-lightdef.49 = 
+lightdef.46 =
+lightdef.47 =
+lightdef.48 =
+lightdef.49 =
 
 ; LANDING LT
-lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:5,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
-lightdef.52 = 
-lightdef.53 = 
-lightdef.54 = 
-lightdef.55 = 
-lightdef.56 = 
-lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:5,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
-lightdef.59 = 
-lightdef.60 = 
-lightdef.61 = 
-lightdef.62 = 
-lightdef.63 = 
+lightdef.50 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.51 = Type:5#Index:2#LocalPosition:-22.5,-6.5,-0.5#LocalRotation:8,0,10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingLeft           ; LDG LT L
+lightdef.52 =
+lightdef.53 =
+lightdef.54 =
+lightdef.55 =
+lightdef.56 =
+lightdef.57 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.58 = Type:5#Index:3#LocalPosition:-22.5,6.5,-0.0.5#LocalRotation:8,0,-10#EffectFile:NL-HS-A321_LandingLarge+#Node:#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_LandingRight          ; LDG LT R
+lightdef.59 =
+lightdef.60 =
+lightdef.61 =
+lightdef.62 =
+lightdef.63 =
 
 ; WING LT
 lightdef.64 = Type:8#Index:1#LocalPosition:15.57,-6.5,4.58#LocalRotation:2,0,145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingLeft      ; WING LT L
-lightdef.65 = 
-lightdef.66 =																																														  
-lightdef.67 = 
+lightdef.65 =
+lightdef.66 =
+lightdef.67 =
 lightdef.68 =
 lightdef.69 = Type:8#Index:2#LocalPosition:15.57,6.5,4.58#LocalRotation:2,0,-145#EffectFile:NL-HS-A321_WingLarge#PotentiometerIndex:1#EmMesh:LIGHT_ASOBO_WingRight     ; WING LT R
-																																																	   
+
 lightdef.70 =
-lightdef.71 =																																																	  
-lightdef.72 =																																																 
+lightdef.71 =
+lightdef.72 =
 lightdef.73 =
 
 
@@ -164,16 +164,18 @@ lightdef.77 = Type:4#Index:8#LocalPosition:35,0,8.3#LocalRotation:80,0,0#EffectF
 lightdef.78 = Type:4#Index:8#LocalPosition:33.8,1.5,9.9#LocalRotation:110,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientOverhead#PotentiometerIndex:86           				; OVHD AMB CB
 
 ; FCU INTEG LT AMBIENT
-lightdef.79 = Type:12#Index:5#LocalPosition:38.52,-0.9,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
-lightdef.80 = Type:12#Index:5#LocalPosition:38.52,-0.740,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
-lightdef.81 = Type:12#Index:5#LocalPosition:38.52,-0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
-lightdef.82 = Type:12#Index:5#LocalPosition:38.52,-0.33,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
-lightdef.83 = Type:12#Index:5#LocalPosition:38.52,-0.18,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
-lightdef.84 = Type:12#Index:5#LocalPosition:38.52,0.170,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
-lightdef.85 = Type:12#Index:5#LocalPosition:38.52,0.35,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
-lightdef.86 = Type:12#Index:5#LocalPosition:38.52,0.56,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
-lightdef.87 = Type:12#Index:5#LocalPosition:38.52,0.74,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
-lightdef.88 = Type:12#Index:5#LocalPosition:38.52,0.90,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
+lightdef.79 = Type:12#Index:5#LocalPosition:38.3775,-0.907405,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 1
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.80 = Type:0#Index:5#LocalPosition:38.3775,-0.738063,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 2
+lightdef.81 = Type:0#Index:5#LocalPosition:38.3775,-0.559805,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 3
+lightdef.82 = Type:12#Index:5#LocalPosition:38.3775,-0.329049,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 4
+lightdef.83 = Type:12#Index:5#LocalPosition:38.3775,-0.180246,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84    					; FCU AMB 5
+lightdef.84 = Type:12#Index:5#LocalPosition:38.3775,0.159389,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 6
+lightdef.85 = Type:12#Index:5#LocalPosition:38.3775,0.346189,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84     					; FCU AMB 7
+; lights above the ND knobs are disabled as there is no screen to bleed light above them
+lightdef.86 = Type:0#Index:5#LocalPosition:38.3775,0.553744,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 8
+lightdef.87 = Type:0#Index:5#LocalPosition:38.3775,0.732994,6.31#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 9
+lightdef.88 = Type:12#Index:5#LocalPosition:38.3775,0.902528,6.26354#LocalRotation:-230,0,0#EffectFile:A32NX_Cockpit_EmissiveAmbientFCU#PotentiometerIndex:84      					; FCU AMB 10
 
 ; PEDESTAL INTEG LT AMBIENT
 lightdef.89 = Type:4#Index:7#LocalPosition:38.60,-0.260,4.40#LocalRotation:-10,0,180#EffectFile:A32NX_Cockpit_EmissiveAmbientPedSwitches#PotentiometerIndex:85     			; PED MID SWITCHES 1
@@ -228,8 +230,8 @@ lightdef.131 = Type:12#Index:3#LocalPosition:38.6,0,4.6#LocalRotation:0,0,0#Effe
 lightdef.132 = Type:12#Index:4#LocalPosition:38.4,2.58,4.59#LocalRotation:0,0,0#EffectFile:A32NX_Cockpit_MainPanelFloodAmbientEnd#PotentiometerIndex:83   					; F/O AMB
 
 ; CPT / F/O TABLE LT
-lightdef.133 = Type:12#Index:1#LocalPosition:38.5,-1.825,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
-lightdef.134 = Type:12#Index:2#LocalPosition:38.5,1.76,5.98#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
+lightdef.133 = Type:12#Index:1#LocalPosition:38.414,-1.843,5.955#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:10  							; CPT TABLE LT
+lightdef.134 = Type:12#Index:2#LocalPosition:38.407,1.841,5.965#LocalRotation:85,0,0#EffectFile:A32NX_Cockpit_MainPanelFlood#PotentiometerIndex:11    							; F/O TABLE LT
 
 ; CTP / F/O CONSOLE/FLOOR LT
 lightdef.135 = Type:4#Index:3#LocalPosition:37.4,-3.67,5.4#LocalRotation:90,0,70#EffectFile:A32NX_Cockpit_Console#PotentiometerIndex:8  									; CONSOLE/FLOOR LT CPT 1
@@ -516,6 +518,7 @@ stick_shaker = 1
 
 [DEICE_SYSTEM]
 structural_deice_type = 1 ; 0 = None, 1 = Heated Leading Edge, 2 = Bleed Air Boots, 3 = Eng Pump Boots
+windshield_deice_rate = 0.033 ; Pct reduction of ice per second -- Clears windshield of ice in 30 seconds
 
 [RADIOS]
 Audio.1 = 1


### PR DESCRIPTION
change of strobe and landing light orientations which cause reflections in the cockpit

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
